### PR TITLE
Added support for Optifine's Dynamic Lighting

### DIFF
--- a/src/main/resources/assets/torchbandolier/optifine/dynamic_lights.properties
+++ b/src/main/resources/assets/torchbandolier/optifine/dynamic_lights.properties
@@ -1,0 +1,9 @@
+# This configuration file allows mods to define dynamic light levels for entities and items.
+# Location: "/assets/<mod_id>/optifine/dynamic_lights.properties"
+
+# Item light levels
+# The item name is automatically expanded with the mod_id.
+# The light level should be between 0 and 15.
+# For example:
+#   items=florb:15 morb:7
+items=torch_bandolier:15 stone_torch_bandolier:15


### PR DESCRIPTION
This adds support for Optifine's Dynamic Lighting based on [this](https://github.com/sp614x/optifine/blob/master/OptiFineDoc/doc/dynamic_lights.properties) Optifine file.

I haven't tested it, because I'm unable to build the project. I can't figure out how to compile with SilentLib—it seems you're compiling with `mavenLocal()`, which must give you the right version of SilentLib. Based on all of my research, though, this should work perfectly!

Would you please be able to build and release a new update of Torch Bandolier for 1.15.2 containing these changes? Some friends and I are using a custom modpack containing both Torch Bandolier and Optifine, and this would be really helpful.